### PR TITLE
fix: bufferline icon background inconsistency

### DIFF
--- a/lua/monokai-v2/init.lua
+++ b/lua/monokai-v2/init.lua
@@ -27,13 +27,6 @@ M.load = function()
   local theme = require("monokai-v2.theme")
   local hl_groups = theme.setup()
 
-  -- Merge bufferline icons into the simplified highlight table
-  -- Note: setup_bufferline_icon() is called by bufferline plugin itself with icon info
-  -- This call here is safe but will return nil/{} since no icon info is provided
-  local bufferline_module = require("monokai-v2.theme.plugins.bufferline")
-  local bufferline_icons = (bufferline_module.setup_bufferline_icon and bufferline_module.setup_bufferline_icon()) or {}
-  hl_groups = vim.tbl_deep_extend("force", hl_groups, bufferline_icons)
-
   cache.compile(config.filter, hl_groups, config)
   cache.load_compiled(config.filter, config)
 end

--- a/lua/monokai-v2/init.lua
+++ b/lua/monokai-v2/init.lua
@@ -20,6 +20,13 @@ M.load = function()
         devicons.setup(colorscheme(config.filter))
       end)
     end
+
+    -- Bufferline icon autocmds are normally set up in theme_util.load(),
+    -- but the cached path skips that. Register them here explicitly.
+    local bufferline_module = require("monokai-v2.theme.plugins.bufferline")
+    if bufferline_module.setup_icon_autocmds then
+      bufferline_module.setup_icon_autocmds()
+    end
     return
   end
 

--- a/lua/monokai-v2/theme/plugins/bufferline.lua
+++ b/lua/monokai-v2/theme/plugins/bufferline.lua
@@ -353,39 +353,47 @@ M.setup_icon_autocmds = function()
   vim.api.nvim_create_autocmd({ "ColorScheme", "BufEnter" }, {
     group = group,
     callback = function()
-      -- Ensure tab colors are initialized (needed when loading from cache,
-      -- since M.get() may not have been called yet).
-      if M.get_tab == nil and M.get then
-        local colorscheme = require("monokai-v2.colorscheme")
-        local config = require("monokai-v2.config")
-        local helper = require("monokai-v2.color_helper")
-        M.get(colorscheme(config.filter), config, helper)
-      end
-
-      local icon_ok, web_devicons = pcall(require, "nvim-web-devicons")
-      if not icon_ok then
+      if vim.g.colors_name ~= "monokai-v2" then
         return
       end
 
-      local theme_util = require("monokai-v2.util.theme")
-      for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
-        pcall(function()
-          local buf_name = vim.api.nvim_buf_get_name(buf_id)
-          if buf_name and buf_name ~= "" then
-            local filename = vim.fn.fnamemodify(buf_name, ":t")
-            local extension = vim.fn.fnamemodify(buf_name, ":e")
-            local _, icon_hl = web_devicons.get_icon(filename, extension, { default = true })
-            local _, icon_color = web_devicons.get_icon_color(filename, extension, { default = true })
+      -- Defer so bufferline.nvim has time to render first;
+      -- we then overwrite its dynamically derived highlights.
+      vim.schedule(function()
+        -- Ensure tab colors are initialized (needed when loading from cache,
+        -- since M.get() may not have been called yet).
+        if M.get_tab == nil and M.get then
+          local colorscheme = require("monokai-v2.colorscheme")
+          local config = require("monokai-v2.config")
+          local helper = require("monokai-v2.color_helper")
+          M.get(colorscheme(config.filter), config, helper)
+        end
 
-            if icon_hl then
-              local icon_highlights = M.setup_bufferline_icon(icon_hl, icon_color)
-              if icon_highlights then
-                theme_util.draw(icon_highlights)
+        local icon_ok, web_devicons = pcall(require, "nvim-web-devicons")
+        if not icon_ok then
+          return
+        end
+
+        local theme_util = require("monokai-v2.util.theme")
+        for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
+          pcall(function()
+            local buf_name = vim.api.nvim_buf_get_name(buf_id)
+            if buf_name and buf_name ~= "" then
+              local filename = vim.fn.fnamemodify(buf_name, ":t")
+              local extension = vim.fn.fnamemodify(buf_name, ":e")
+              local _, icon_hl = web_devicons.get_icon(filename, extension, { default = true })
+              local _, icon_color = web_devicons.get_icon_color(filename, extension, { default = true })
+
+              if icon_hl then
+                local icon_highlights = M.setup_bufferline_icon(icon_hl, icon_color)
+                if icon_highlights then
+                  theme_util.draw(icon_highlights)
+                end
               end
             end
-          end
-        end)
-      end
+          end)
+        end
+      end)
     end,
   })
 end

--- a/lua/monokai-v2/theme/plugins/bufferline.lua
+++ b/lua/monokai-v2/theme/plugins/bufferline.lua
@@ -341,4 +341,44 @@ M.setup_bufferline_icon = function(icon_hl_name, icon_color)
   return skeleton
 end
 
+--- Set up autocmds to create bufferline icon highlights for all buffers.
+--- This ensures icon backgrounds match tab backgrounds since bufferline.nvim
+--- derives its own internal colors that may not match the theme's highlights.
+M.setup_icon_autocmds = function()
+  if not M.setup_bufferline_icon then
+    return
+  end
+
+  local group = vim.api.nvim_create_augroup("MonokaiV2BufferlineIcons", { clear = true })
+  vim.api.nvim_create_autocmd({ "ColorScheme", "BufEnter" }, {
+    group = group,
+    callback = function()
+      local icon_ok, web_devicons = pcall(require, "nvim-web-devicons")
+      if not icon_ok then
+        return
+      end
+
+      local theme_util = require("monokai-v2.util.theme")
+      for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
+        pcall(function()
+          local buf_name = vim.api.nvim_buf_get_name(buf_id)
+          if buf_name and buf_name ~= "" then
+            local filename = vim.fn.fnamemodify(buf_name, ":t")
+            local extension = vim.fn.fnamemodify(buf_name, ":e")
+            local _, icon_hl = web_devicons.get_icon(filename, extension, { default = true })
+            local _, icon_color = web_devicons.get_icon_color(filename, extension, { default = true })
+
+            if icon_hl then
+              local icon_highlights = M.setup_bufferline_icon(icon_hl, icon_color)
+              if icon_highlights then
+                theme_util.draw(icon_highlights)
+              end
+            end
+          end
+        end)
+      end
+    end,
+  })
+end
+
 return M

--- a/lua/monokai-v2/theme/plugins/bufferline.lua
+++ b/lua/monokai-v2/theme/plugins/bufferline.lua
@@ -353,6 +353,15 @@ M.setup_icon_autocmds = function()
   vim.api.nvim_create_autocmd({ "ColorScheme", "BufEnter" }, {
     group = group,
     callback = function()
+      -- Ensure tab colors are initialized (needed when loading from cache,
+      -- since M.get() may not have been called yet).
+      if M.get_tab == nil and M.get then
+        local colorscheme = require("monokai-v2.colorscheme")
+        local config = require("monokai-v2.config")
+        local helper = require("monokai-v2.color_helper")
+        M.get(colorscheme(config.filter), config, helper)
+      end
+
       local icon_ok, web_devicons = pcall(require, "nvim-web-devicons")
       if not icon_ok then
         return

--- a/lua/monokai-v2/theme/plugins/snacks.lua
+++ b/lua/monokai-v2/theme/plugins/snacks.lua
@@ -120,7 +120,10 @@ function M.get(c, config, hp)
     SnacksPickerTotals = { fg = c.base.dimmed1 },
     SnacksPickerPromptCounter = { fg = c.base.white, bold = true },
     SnacksPickerSpinner = { fg = c.base.yellow },
-    SnacksPickerToggle = { fg = c.base.cyan, bg = hp.blend(c.base.cyan, 0.1, c.editor.background) },
+    SnacksPickerToggle = {
+      bg = config.filter == "light" and c.base.red or c.base.yellow,
+      fg = c.base.black,
+    },
     SnacksPickerDimmed = { fg = c.base.dimmed2 },
     SnacksPickerSelected = { fg = c.base.yellow },
     SnacksPickerUnselected = { fg = c.base.dimmed1 },

--- a/lua/monokai-v2/theme/plugins/snacks.lua
+++ b/lua/monokai-v2/theme/plugins/snacks.lua
@@ -120,10 +120,7 @@ function M.get(c, config, hp)
     SnacksPickerTotals = { fg = c.base.dimmed1 },
     SnacksPickerPromptCounter = { fg = c.base.white, bold = true },
     SnacksPickerSpinner = { fg = c.base.yellow },
-    SnacksPickerToggle = {
-      bg = config.filter == "light" and c.base.red or c.base.yellow,
-      fg = c.base.black,
-    },
+    SnacksPickerToggle = { fg = c.base.cyan, bg = hp.blend(c.base.cyan, 0.1, c.editor.background) },
     SnacksPickerDimmed = { fg = c.base.dimmed2 },
     SnacksPickerSelected = { fg = c.base.yellow },
     SnacksPickerUnselected = { fg = c.base.dimmed1 },

--- a/lua/monokai-v2/util/theme.lua
+++ b/lua/monokai-v2/util/theme.lua
@@ -82,15 +82,12 @@ function M.load(hl_group_tbl)
 
   M.draw(hl_group_tbl)
 
-  -- Note: setup_bufferline_icon() is called by bufferline plugin itself with icon info
-  -- This is safe but will return nil/{} since no icon info is provided
-  -- The bufferline plugin will call this function directly when it needs icon highlights
+  -- Set up bufferline icon highlights so icon backgrounds match tab backgrounds.
+  -- Bufferline.nvim creates icon highlights dynamically using derived colors
+  -- that may not match the theme's explicit highlights.
   local bufferline_module = require("monokai-v2.theme.plugins.bufferline")
-  if bufferline_module.setup_bufferline_icon then
-    local bufferline_icon_hl_group_tbl = bufferline_module.setup_bufferline_icon()
-    if bufferline_icon_hl_group_tbl then
-      M.draw(bufferline_icon_hl_group_tbl)
-    end
+  if bufferline_module.setup_icon_autocmds then
+    bufferline_module.setup_icon_autocmds()
   end
   load_autocmds()
 end


### PR DESCRIPTION
## Problem

Bufferline.nvim dynamically creates `BufferLineDevIcon{NAME}{Selected|Inactive|""}` highlight groups by merging its internal tab color tables with the devicon foreground color. Because it derives these internally, the resulting icon backgrounds may not match the theme's explicit tab highlight colors — especially when the theme uses custom alpha blending or lightened backgrounds.

## Changes

1. **Proactively create icon highlights via autocmd** (`setup_icon_autocmds`)
   - Hooks `ColorScheme` and `BufEnter` to set `BufferLineDevIcon*` highlights for all existing buffers.
   - Ensures icon `bg` matches the theme's `tab.activeBackground`, `tab.inactiveBackground`, and `tab.unfocusedActiveBackground` exactly.

2. **Initialize `get_tab` in cached loading path**
   - When the theme loads from compiled cache, `bufferline.get()` is skipped, so `M.get_tab` is `nil`.
   - The autocmd callback now explicitly calls `M.get()` to initialize tab colors before generating icon highlights.

3. **Defer callback with `vim.schedule()`**
   - Gives bufferline.nvim time to render before overwriting its dynamically derived highlights.
   - Also guards with `vim.g.colors_name == \"monokai-v2\"` to avoid affecting other colorschemes.

## Testing

- Verified locally that CUDA, Lua, Python, and other devicons now have consistent backgrounds across selected, visible, and inactive bufferline tabs.
- Tested with both cache-cleared and cached loading paths.