### PR TITLE
fix(bufferline): centralize icon autocmds and scope BufEnter to current buffer

### DIFF
--- a/lua/monokai-v2/init.lua
+++ b/lua/monokai-v2/init.lua
@@ -7,6 +7,14 @@ M.setup = function(opts)
   command.create_commands()
 end
 
+local function setup_plugin_icon_handlers()
+  local bufferline_module = require("monokai-v2.theme.plugins.bufferline")
+  if bufferline_module.register_icon_handler then
+    bufferline_module.register_icon_handler()
+  end
+  require("monokai-v2.util.theme").setup_plugin_icon_autocmds()
+end
+
 M.load = function()
   local config = require("monokai-v2.config")
   local cache = require("monokai-v2.cache")
@@ -23,12 +31,7 @@ M.load = function()
 
     -- Register plugin icon handlers and set up centralized autocmds.
     -- The cached path skips theme_util.load(), so we do it here.
-    local bufferline_module = require("monokai-v2.theme.plugins.bufferline")
-    if bufferline_module.register_icon_handler then
-      bufferline_module.register_icon_handler()
-    end
-    local theme_util = require("monokai-v2.util.theme")
-    theme_util.setup_plugin_icon_autocmds()
+    setup_plugin_icon_handlers()
     return
   end
 
@@ -40,12 +43,7 @@ M.load = function()
   cache.load_compiled(config.filter, config)
 
   -- Register plugin icon handlers in the non-cached path as well.
-  local bufferline_module = require("monokai-v2.theme.plugins.bufferline")
-  if bufferline_module.register_icon_handler then
-    bufferline_module.register_icon_handler()
-  end
-  local theme_util = require("monokai-v2.util.theme")
-  theme_util.setup_plugin_icon_autocmds()
+  setup_plugin_icon_handlers()
 end
 M._load = function(filter)
   require("monokai-v2.config").extend({ filter = filter })

--- a/lua/monokai-v2/init.lua
+++ b/lua/monokai-v2/init.lua
@@ -21,12 +21,14 @@ M.load = function()
       end)
     end
 
-    -- Bufferline icon autocmds are normally set up in theme_util.load(),
-    -- but the cached path skips that. Register them here explicitly.
+    -- Register plugin icon handlers and set up centralized autocmds.
+    -- The cached path skips theme_util.load(), so we do it here.
     local bufferline_module = require("monokai-v2.theme.plugins.bufferline")
-    if bufferline_module.setup_icon_autocmds then
-      bufferline_module.setup_icon_autocmds()
+    if bufferline_module.register_icon_handler then
+      bufferline_module.register_icon_handler()
     end
+    local theme_util = require("monokai-v2.util.theme")
+    theme_util.setup_plugin_icon_autocmds()
     return
   end
 
@@ -36,6 +38,14 @@ M.load = function()
 
   cache.compile(config.filter, hl_groups, config)
   cache.load_compiled(config.filter, config)
+
+  -- Register plugin icon handlers in the non-cached path as well.
+  local bufferline_module = require("monokai-v2.theme.plugins.bufferline")
+  if bufferline_module.register_icon_handler then
+    bufferline_module.register_icon_handler()
+  end
+  local theme_util = require("monokai-v2.util.theme")
+  theme_util.setup_plugin_icon_autocmds()
 end
 M._load = function(filter)
   require("monokai-v2.config").extend({ filter = filter })

--- a/lua/monokai-v2/theme/plugins/bufferline.lua
+++ b/lua/monokai-v2/theme/plugins/bufferline.lua
@@ -367,6 +367,9 @@ M.register_icon_handler = function()
 
     for _, buf_id in ipairs(bufs) do
       pcall(function()
+        if not vim.api.nvim_buf_is_valid(buf_id) then
+          return
+        end
         local buf_name = vim.api.nvim_buf_get_name(buf_id)
         if buf_name and buf_name ~= "" then
           local filename = vim.fn.fnamemodify(buf_name, ":t")

--- a/lua/monokai-v2/theme/plugins/bufferline.lua
+++ b/lua/monokai-v2/theme/plugins/bufferline.lua
@@ -341,61 +341,49 @@ M.setup_bufferline_icon = function(icon_hl_name, icon_color)
   return skeleton
 end
 
---- Set up autocmds to create bufferline icon highlights for all buffers.
+--- Register bufferline's icon background fix with the centralized handler.
 --- This ensures icon backgrounds match tab backgrounds since bufferline.nvim
 --- derives its own internal colors that may not match the theme's highlights.
-M.setup_icon_autocmds = function()
+M.register_icon_handler = function()
   if not M.setup_bufferline_icon then
     return
   end
 
-  local group = vim.api.nvim_create_augroup("MonokaiV2BufferlineIcons", { clear = true })
-  vim.api.nvim_create_autocmd({ "ColorScheme", "BufEnter" }, {
-    group = group,
-    callback = function()
-      if vim.g.colors_name ~= "monokai-v2" then
-        return
-      end
+  local theme_util = require("monokai-v2.util.theme")
+  theme_util.register_plugin_icon_handler("bufferline", function(_, bufs)
+    -- Ensure tab colors are initialized (needed when loading from cache,
+    -- since M.get() may not have been called yet).
+    if M.get_tab == nil and M.get then
+      local colorscheme = require("monokai-v2.colorscheme")
+      local config = require("monokai-v2.config")
+      local helper = require("monokai-v2.color_helper")
+      M.get(colorscheme(config.filter), config, helper)
+    end
 
-      -- Defer so bufferline.nvim has time to render first;
-      -- we then overwrite its dynamically derived highlights.
-      vim.schedule(function()
-        -- Ensure tab colors are initialized (needed when loading from cache,
-        -- since M.get() may not have been called yet).
-        if M.get_tab == nil and M.get then
-          local colorscheme = require("monokai-v2.colorscheme")
-          local config = require("monokai-v2.config")
-          local helper = require("monokai-v2.color_helper")
-          M.get(colorscheme(config.filter), config, helper)
-        end
+    local icon_ok, web_devicons = pcall(require, "nvim-web-devicons")
+    if not icon_ok then
+      return
+    end
 
-        local icon_ok, web_devicons = pcall(require, "nvim-web-devicons")
-        if not icon_ok then
-          return
-        end
+    for _, buf_id in ipairs(bufs) do
+      pcall(function()
+        local buf_name = vim.api.nvim_buf_get_name(buf_id)
+        if buf_name and buf_name ~= "" then
+          local filename = vim.fn.fnamemodify(buf_name, ":t")
+          local extension = vim.fn.fnamemodify(buf_name, ":e")
+          local _, icon_hl = web_devicons.get_icon(filename, extension, { default = true })
+          local _, icon_color = web_devicons.get_icon_color(filename, extension, { default = true })
 
-        local theme_util = require("monokai-v2.util.theme")
-        for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
-          pcall(function()
-            local buf_name = vim.api.nvim_buf_get_name(buf_id)
-            if buf_name and buf_name ~= "" then
-              local filename = vim.fn.fnamemodify(buf_name, ":t")
-              local extension = vim.fn.fnamemodify(buf_name, ":e")
-              local _, icon_hl = web_devicons.get_icon(filename, extension, { default = true })
-              local _, icon_color = web_devicons.get_icon_color(filename, extension, { default = true })
-
-              if icon_hl then
-                local icon_highlights = M.setup_bufferline_icon(icon_hl, icon_color)
-                if icon_highlights then
-                  theme_util.draw(icon_highlights)
-                end
-              end
+          if icon_hl then
+            local icon_highlights = M.setup_bufferline_icon(icon_hl, icon_color)
+            if icon_highlights then
+              theme_util.draw(icon_highlights)
             end
-          end)
+          end
         end
       end)
-    end,
-  })
+    end
+  end)
 end
 
 return M

--- a/lua/monokai-v2/theme/plugins/snacks.lua
+++ b/lua/monokai-v2/theme/plugins/snacks.lua
@@ -31,6 +31,7 @@ function M.get(c, config, hp)
   local picker_bg = isPickerBackgroundClear and transparent_bg or result_bg
   local picker_border_bg = transparent_bg
   local picker_border_fg = isPickerBackgroundClear and transparent_bg_border or result_bg
+  local title_accent_bg = config.filter == "light" and c.base.red or c.base.yellow
 
   return {
     -- ══════════════════════════════════════════════════════════════════════
@@ -53,7 +54,7 @@ function M.get(c, config, hp)
     SnacksPickerBorder = isPickerBackgroundClear and { bg = transparent_bg, fg = c.tab.unfocusedActiveBorder }
       or { bg = c.editor.background, fg = c.editorHoverWidget.background },
     SnacksPickerTitle = {
-      bg = config.filter == "light" and c.base.red or c.base.yellow,
+      bg = title_accent_bg,
       fg = c.base.black,
       bold = true,
     },
@@ -105,7 +106,7 @@ function M.get(c, config, hp)
     -- ══════════════════════════════════════════════════════════════════════
     -- Picker - Content styling
     -- ══════════════════════════════════════════════════════════════════════
-    SnacksPickerMatch = { fg = config.filter == "light" and c.base.red or c.base.yellow, bold = true },
+    SnacksPickerMatch = { fg = title_accent_bg, bold = true },
     SnacksPickerSearch = { link = "Search" },
     SnacksPickerFile = { fg = c.base.white },
     SnacksPickerDir = { fg = c.base.dimmed1 },

--- a/lua/monokai-v2/util/theme.lua
+++ b/lua/monokai-v2/util/theme.lua
@@ -8,6 +8,46 @@ local function load_autocmds()
   pcall(require, "monokai-v2.autocmds")
 end
 
+-- Plugin icon handlers for fixing dynamically-derived devicon backgrounds.
+-- Each handler is a function(event: string, bufs: integer[]) that updates
+-- highlight groups for the given buffers.
+local plugin_icon_handlers = {}
+local plugin_icon_autocmd_registered = false
+
+--- Register a plugin-specific icon background fix handler.
+--- @param name string
+--- @param handler fun(event: string, bufs: integer[])
+function M.register_plugin_icon_handler(name, handler)
+  plugin_icon_handlers[name] = handler
+end
+
+--- Set up a single centralized autocmd that dispatches to all registered
+--- plugin icon handlers. BufEnter scopes to the entered buffer only;
+--- ColorScheme sweeps all buffers since highlights were cleared.
+function M.setup_plugin_icon_autocmds()
+  if plugin_icon_autocmd_registered or vim.tbl_isempty(plugin_icon_handlers) then
+    return
+  end
+  plugin_icon_autocmd_registered = true
+
+  local group = vim.api.nvim_create_augroup("MonokaiV2PluginIcons", { clear = true })
+  vim.api.nvim_create_autocmd({ "ColorScheme", "BufEnter" }, {
+    group = group,
+    callback = function(args)
+      if vim.g.colors_name ~= "monokai-v2" then
+        return
+      end
+
+      vim.schedule(function()
+        local bufs = args.event == "BufEnter" and { args.buf } or vim.api.nvim_list_bufs()
+        for _, handler in pairs(plugin_icon_handlers) do
+          pcall(handler, args.event, bufs)
+        end
+      end)
+    end,
+  })
+end
+
 ---@param hex_color HexColor
 ---@param base? HexColor
 ---@return HexColor?
@@ -82,13 +122,13 @@ function M.load(hl_group_tbl)
 
   M.draw(hl_group_tbl)
 
-  -- Set up bufferline icon highlights so icon backgrounds match tab backgrounds.
-  -- Bufferline.nvim creates icon highlights dynamically using derived colors
-  -- that may not match the theme's explicit highlights.
+  -- Set up plugin icon autocmds so dynamically-derived devicon backgrounds
+  -- (e.g. BufferLineDevIcon*) are corrected for all registered plugins.
   local bufferline_module = require("monokai-v2.theme.plugins.bufferline")
-  if bufferline_module.setup_icon_autocmds then
-    bufferline_module.setup_icon_autocmds()
+  if bufferline_module.register_icon_handler then
+    bufferline_module.register_icon_handler()
   end
+  M.setup_plugin_icon_autocmds()
   load_autocmds()
 end
 

--- a/lua/monokai-v2/util/theme.lua
+++ b/lua/monokai-v2/util/theme.lua
@@ -12,7 +12,6 @@ end
 -- Each handler is a function(event: string, bufs: integer[]) that updates
 -- highlight groups for the given buffers.
 local plugin_icon_handlers = {}
-local plugin_icon_autocmd_registered = false
 
 --- Register a plugin-specific icon background fix handler.
 --- @param name string
@@ -25,10 +24,9 @@ end
 --- plugin icon handlers. BufEnter scopes to the entered buffer only;
 --- ColorScheme sweeps all buffers since highlights were cleared.
 function M.setup_plugin_icon_autocmds()
-  if plugin_icon_autocmd_registered or vim.tbl_isempty(plugin_icon_handlers) then
+  if vim.tbl_isempty(plugin_icon_handlers) then
     return
   end
-  plugin_icon_autocmd_registered = true
 
   local group = vim.api.nvim_create_augroup("MonokaiV2PluginIcons", { clear = true })
   vim.api.nvim_create_autocmd({ "ColorScheme", "BufEnter" }, {
@@ -130,14 +128,6 @@ function M.load(hl_group_tbl)
   end
 
   M.draw(hl_group_tbl)
-
-  -- Set up plugin icon autocmds so dynamically-derived devicon backgrounds
-  -- (e.g. BufferLineDevIcon*) are corrected for all registered plugins.
-  local bufferline_module = require("monokai-v2.theme.plugins.bufferline")
-  if bufferline_module.register_icon_handler then
-    bufferline_module.register_icon_handler()
-  end
-  M.setup_plugin_icon_autocmds()
   load_autocmds()
 end
 

--- a/lua/monokai-v2/util/theme.lua
+++ b/lua/monokai-v2/util/theme.lua
@@ -46,6 +46,15 @@ function M.setup_plugin_icon_autocmds()
       end)
     end,
   })
+
+  -- Backfill already-open buffers so icons are corrected immediately.
+  vim.schedule(function()
+    if vim.g.colors_name == "monokai-v2" then
+      for _, handler in pairs(plugin_icon_handlers) do
+        pcall(handler, "ColorScheme", vim.api.nvim_list_bufs())
+      end
+    end
+  end)
 end
 
 ---@param hex_color HexColor


### PR DESCRIPTION
Hey @khoido2003,

Following up on the performance concern and centralized fix you mentioned in #16:

- `BufEnter` now only processes the entered buffer instead of iterating all open buffers on every switch
- Moved autocmd setup into `theme_util` so other plugins (Snacks, fzf-lua, etc.) can just register a handler instead of each creating their own autocmds
- Also fixed the missing icon autocmd registration in the non-cached loading path

You can try `:MonokaiCache clear` to clear the cache and restart Neovim to verify.

Refs: #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized plugin icon handler system to register and dispatch icon updates.

* **Bug Fixes**
  * Fixed inconsistent icon highlighting when the theme is loaded from cache or early startup.

* **Improvements**
  * More reliable, consistent icon styling across components.
  * Updated snacks picker title and match colors for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->